### PR TITLE
fix: ignore additional CVSS4 metrics

### DIFF
--- a/src/common/models/cve.py
+++ b/src/common/models/cve.py
@@ -159,7 +159,7 @@ class Metrics(BaseModel):
     """
 
     class Config:
-       extra = Extra.forbid
+       extra = Extra.ignore
 
     cvssMetricV31: Optional[List[CvssV31]] = Field(None, description='CVSS V3.1 score.')
     cvssMetricV30: Optional[List[CvssV30]] = Field(None, description='CVSS V3.0 score.')


### PR DESCRIPTION
This PR is a temporary fix for #13

It will just ignore additional cvssMetricV40 data and prevent internal server errors until a cvssMetricV40 class is implemented.

~~Users may have to rebuild the existing PSQL database to re-trigger `generate_vuln_cpe()` and `generate_vuln_cpes()`.~~