### PR TITLE
fix: relax reference url type

### DIFF
--- a/src/common/models/cve.py
+++ b/src/common/models/cve.py
@@ -32,7 +32,7 @@ class Reference(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    url: constr(regex=r'^(ftp|http)s?://\S+$', max_length=500)
+    url: str
     source: Optional[str] = None
     tags: Optional[List[str]] = None
 


### PR DESCRIPTION
This change can fix #15.

However, it also introduces the possibility for unvalidated reference urls. So if there are other applications pulling data from the API, it may happen that untrusted data is returned.

However, according to OWASP, one should never trust data from remote origins. So other applications relying on fastcve should execute their own validations too.