### PR TITLE
feat: support download epss data with today's date

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker exec fastcve load --data cve cpe
 
 this will fetch the new/modified data for the period from the last data fetch (for a max of `n` days: parameter set in the config. NVD is allowing max 120 days period)
 
-If there is a need to repopulate the DB for the CWE/CAPEC info, then `--full` and `--drop` options are available for the CWE/CAPEC info load command. `--full` will cause to ignore the fact the CWE/CAPEC data is already present and `--drop` will cause to drop any exiting CWE/CAPEC related data before processing the new downloaded data. When using `--data epss` in combination with `--epss-now`, the load command explicitly fetches the EPSS data for the current date. If `--epss-now` is not specified, the script defaults to retrieving EPSS data from the previous day.
+If there is a need to repopulate the DB for the CWE/CAPEC info, then `--full` and `--drop` options are available for the CWE/CAPEC info load command. `--full` will cause to ignore the fact the CWE/CAPEC data is already present and `--drop` will cause to drop any exiting CWE/CAPEC related data before processing the new downloaded data. When using `--data epss` in combination with `--epss-now`, the load command explicitly fetches the EPSS data for the current date. If `--epss-now` is not specified, the script defaults to retrieve EPSS data from the previous day.
 
 - search for the data: **get the CVEs details (JSON) for a list of CVE-IDs**
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker exec fastcve load --data cve cpe
 
 this will fetch the new/modified data for the period from the last data fetch (for a max of `n` days: parameter set in the config. NVD is allowing max 120 days period)
 
-If there is a need to repopulate the DB for the CWE/CAPEC info, then `--full` and `--drop` options are available for the CWE/CAPEC info load command. `--full` will cause to ignore the fact the CWE/CAPEC data is already present and `--drop` will cause to drop any exiting CWE/CAPEC related data before processing the new downloaded data.
+If there is a need to repopulate the DB for the CWE/CAPEC info, then `--full` and `--drop` options are available for the CWE/CAPEC info load command. `--full` will cause to ignore the fact the CWE/CAPEC data is already present and `--drop` will cause to drop any exiting CWE/CAPEC related data before processing the new downloaded data. When using `--data epss` in combination with `--epss-now`, the load command explicitly fetches the EPSS data for the current date. If `--epss-now` is not specified, the script defaults to retrieving EPSS data from the previous day.
 
 - search for the data: **get the CVEs details (JSON) for a list of CVE-IDs**
 ```

--- a/src/load
+++ b/src/load
@@ -230,10 +230,13 @@ def fetch_data_feed(appctx, data_name, args):
     # download the file
     data_url = appctx.config.get_param(f'fetch.url.{data_name}', None)
 
-    if data_name == 'epss':
+    if data_name == 'epss' and not args.epss_now:
         previous_day = date.today() - timedelta(days=1)
         #download the EPSS data using the previous day from the current date.
         data_url = f"{data_url}/epss_scores-{previous_day.strftime('%Y-%m-%d')}.csv.gz"
+    elif data_name == 'epss' and args.epss_now:
+        # force downloading EPSS data with today's date
+        data_url = f"{data_url}/epss_scores-{date.today().strftime('%Y-%m-%d')}.csv.gz"
 
     if not data_url: raise ValidationError(f'{data_name} url config param not specified')
 
@@ -813,6 +816,7 @@ def main():
     parser.add_argument('-t', '--to', dest='to_date', action='store', help='To Date YYYY-MM-DD["T"HH:MI:SS]')
     parser.add_argument('-o', '--offset', dest='offset', action='store', help='Data Fetch offset')
     parser.add_argument('-p', '--profile', dest='profile', action='store_true', help='enable app profiling')
+    parser.add_argument('--epss-now', dest='epss_now', action='store_true', help='Fetch latest EPSS data for today')
 
     argcomplete.autocomplete(parser)
 

--- a/src/load
+++ b/src/load
@@ -231,7 +231,7 @@ def fetch_data_feed(appctx, data_name, args):
     data_url = appctx.config.get_param(f'fetch.url.{data_name}', None)
 
     if data_name == 'epss':
-        days_delta = 0 if args.epss_now or 1
+        days_delta = 0 if args.epss_now else 1
         epss_date = date.today() - timedelta(days=days_delta)
         data_url = f"{data_url}/epss_scores-{epss_date.strftime('%Y-%m-%d')}.csv.gz"
 

--- a/src/load
+++ b/src/load
@@ -230,13 +230,10 @@ def fetch_data_feed(appctx, data_name, args):
     # download the file
     data_url = appctx.config.get_param(f'fetch.url.{data_name}', None)
 
-    if data_name == 'epss' and not args.epss_now:
-        previous_day = date.today() - timedelta(days=1)
-        #download the EPSS data using the previous day from the current date.
-        data_url = f"{data_url}/epss_scores-{previous_day.strftime('%Y-%m-%d')}.csv.gz"
-    elif data_name == 'epss' and args.epss_now:
-        # force downloading EPSS data with today's date
-        data_url = f"{data_url}/epss_scores-{date.today().strftime('%Y-%m-%d')}.csv.gz"
+    if data_name == 'epss':
+        days_delta = 0 if args.epss_now or 1
+        epss_date = date.today() - timedelta(days=days_delta)
+        data_url = f"{data_url}/epss_scores-{epss_date.strftime('%Y-%m-%d')}.csv.gz"
 
     if not data_url: raise ValidationError(f'{data_name} url config param not specified')
 

--- a/src/load
+++ b/src/load
@@ -219,7 +219,7 @@ def fetch_data_feed(appctx, data_name, args):
 
     fetch_data_info = fetch_status(appctx, data_name, args)
     if fetch_data_info and not args.full:
-        if data_name == 'epss' and fetch_data_info['last_modified_date'].date() != date.today()-timedelta(days=1):
+        if (data_name == 'epss' and fetch_data_info['last_modified_date'].date() != date.today()-timedelta(days=1)) or (data_name == 'epss' and args.epss_now):
             pass
         elif data_name == 'kev':
             pass

--- a/src/load
+++ b/src/load
@@ -219,7 +219,7 @@ def fetch_data_feed(appctx, data_name, args):
 
     fetch_data_info = fetch_status(appctx, data_name, args)
     if fetch_data_info and not args.full:
-        if (data_name == 'epss' and fetch_data_info['last_modified_date'].date() != date.today()-timedelta(days=1)) or (data_name == 'epss' and args.epss_now):
+        if data_name == 'epss' and ((not args.epss_now and fetch_data_info['last_modified_date'].date() != date.today() - timedelta(days=1)) or (args.epss_now and fetch_data_info['last_modified_date'].date() != date.today())):
             pass
         elif data_name == 'kev':
             pass


### PR DESCRIPTION
Implements a new argparse cli parameter `--epss-now`, which allows downloading EPSS data from the API with today's date.

Feature will fix #19