### PR TITLE
fix: adjust data modal to allow new or missing nvd data

### DIFF
--- a/src/common/models/cve.py
+++ b/src/common/models/cve.py
@@ -105,7 +105,7 @@ class CvssV30(BaseModel):
 
     source: str
     type: Type
-    cvssData: CveCvssDataV30 
+    cvssData: CveCvssDataV30
     exploitabilityScore: Optional[confloat(ge=0.0, le=10.0)] = Field(
         None, description='CVSS subscore.'
     )
@@ -168,7 +168,8 @@ class Metrics(BaseModel):
     """
 
     class Config:
-       extra = Extra.forbid
+       #extra = Extra.forbid # see https://github.com/binareio/FastCVE/issues/26
+       extra = Extra.allow
 
     cvssMetricV40: Optional[List[CvssV40]] = Field(None, description='CVSS V4.0 score.')
     cvssMetricV31: Optional[List[CvssV31]] = Field(None, description='CVSS V3.1 score.')
@@ -183,7 +184,8 @@ class Config(BaseModel):
 
     operator: Optional[Operator] = None
     negate: Optional[bool] = None
-    nodes: List[Node]
+    #nodes: List[Node] # see https://github.com/binareio/FastCVE/issues/27
+    nodes: List[Node] = Field(default_factory=list)
 
 class CveItem(BaseModel):
     class Config:


### PR DESCRIPTION
This PR fixes the issues outlined in:

- https://github.com/binareio/FastCVE/issues/26
- https://github.com/binareio/FastCVE/issues/27

NVD has introduced new metric fields that are currently not supported by FastCVE's Pydantic models. Because the models reject unknown fields, affected CVEs can cause API response validation to fail with an HTTP 500 error.

Additionally, some newer CVE records contain configuration entries where the nodes field is missing. FastCVE currently treats this field as mandatory, which can also cause response validation to fail.

This PR makes the CVE models more tolerant of these NVD schema variations and prevents valid search results from failing due to newly introduced or optional fields.